### PR TITLE
fixes Wrong country assigned for US profile. (#14)

### DIFF
--- a/lib/linkedin-scraper.rb
+++ b/lib/linkedin-scraper.rb
@@ -2,6 +2,7 @@ require "rubygems"
 require "mechanize"
 require "cgi"
 require "net/http"
+require "geocoder"
 Dir["#{File.expand_path(File.dirname(__FILE__))}/linkedin-scraper/*.rb"].each {|file| require file }
 
 

--- a/lib/linkedin-scraper/profile.rb
+++ b/lib/linkedin-scraper/profile.rb
@@ -94,7 +94,7 @@ module Linkedin
     end
 
     def get_country page
-      return page.at(".locality").text.split(",").last.strip if page.search(".locality").first
+      return Geocoder.search(page.at(".locality").text.split(",").last.strip).first.country if page.search(".locality").first && Geocoder.search(page.at(".locality").text.split(",").last.strip).first
     end
 
     def get_industry page

--- a/linkedin-scraper.gemspec
+++ b/linkedin-scraper.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{when a url of  public linkedin profile page is given it scrapes the entire page and converts into a accessible object}
   gem.homepage      = "https://github.com/yatishmehta27/linkedin-scraper"
   gem.add_dependency(%q<mechanize>, [">= 0"])
+  gem.add_dependency('geocoder', '~> 1.1.8')
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})

--- a/spec/linkedin-scraper/profile_spec.rb
+++ b/spec/linkedin-scraper/profile_spec.rb
@@ -15,6 +15,12 @@ describe Linkedin::Profile do
     end
   end
 
+  describe ".country" do
+    it 'returns the country' do
+      expect(@profile.country).to eq "United States"
+    end
+  end
+
   describe ".first_name" do
     it 'returns the first and last name of the profile' do
       expect(@profile.first_name).to eq "Justin"


### PR DESCRIPTION
It may be overkill. I used Geocoder to get the country based on the
locality info that we previously scraped.  I don't see any other option
other than to remove the country method since I don't believe LinkedIn
puts country info on public profiles for profiles in the US.
