### PR TITLE
Fix for companies dates

### DIFF
--- a/lib/linkedin-scraper/profile.rb
+++ b/lib/linkedin-scraper/profile.rb
@@ -155,10 +155,10 @@ module Linkedin
           company[:company]     = node.at('h4').text.gsub(/\s+|\n/, ' ').strip if node.at('h4')
           company[:description] = node.at(".description.#{type}-position").text.gsub(/\s+|\n/, ' ').strip if node.at(".description.#{type}-position")
 
-          start_date  = node.at('.dtstart')['title']
+          start_date  = node.at('.dtstart')['title'] rescue nil
           company[:start_date] = parse_date(start_date) rescue nil
 
-          end_date = node.at('.dtend')['title']
+          end_date = node.at('.dtend')['title'] rescue nil
           company[:end_date] = parse_date(end_date) rescue nil
 
           company_link = node.at('h4/strong/a')['href'] if node.at('h4/strong/a')


### PR DESCRIPTION
Hi,

Just playing around with the gem I noticed it doesn't parse non-english dates, for example:

```
<abbr class="dtstart" title="2010-02-01">febrero de 2010</abbr>
<abbr class="dtend" title="2010-08-01">agosto de 2010</abbr>
```

So instead of using node.at('.dtend').text I went for node.at('.dtend')['title'] as title in abbr seems to contain the date.

Let me know what you think, 
