### PR TITLE
disable see-more pills to #skills, add open_timeout parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ as well
 
     profile = Linkedin::Profile.new("http://www.linkedin.com/in/jeffweiner08", { company_details: true, proxy_ip: '127.0.0.1', proxy_port: '3128', username: 'user', password: 'pass' })
 
+It's also possible to set number of seconds to wait for the connection to open.
+Scraper will throw exception after given timeout. E. g. to set two seconds long timeout
+pass `open_timeout: 2` in options. Defaults to 60 seconds.
+
+    profile = Linkedin::Profile.new("http://www.linkedin.com/in/jeffweiner08", {open_timeout: 2 })
+
 The returning object responds to the following methods
 
 

--- a/lib/linkedin-scraper/profile.rb
+++ b/lib/linkedin-scraper/profile.rb
@@ -88,7 +88,7 @@ module Linkedin
     end
 
     def skills
-      @skills ||= (@page.search('.pills .skill:not(.see-less)').map { |skill| skill.text.strip if skill.text } rescue nil)
+      @skills ||= (@page.search('.pills .skill:not(.see-less):not(.see-more)').map { |skill| skill.text.strip if skill.text } rescue nil)
     end
 
     def past_companies
@@ -289,6 +289,7 @@ module Linkedin
         agent.user_agent = Linkedin::UserAgent.randomize
         if !@options.empty?
           agent.set_proxy(@options[:proxy_ip], @options[:proxy_port], @options[:username], @options[:password])
+          agent.open_timeout = @options[:open_timeout]
         end
         agent.max_history = 0
       end

--- a/lib/linkedin-scraper/profile.rb
+++ b/lib/linkedin-scraper/profile.rb
@@ -290,6 +290,7 @@ module Linkedin
         if !@options.empty?
           agent.set_proxy(@options[:proxy_ip], @options[:proxy_port], @options[:username], @options[:password])
           agent.open_timeout = @options[:open_timeout]
+          agent.read_timeout = @options[:read_timeout]
         end
         agent.max_history = 0
       end


### PR DESCRIPTION
- In skills sections there's optionally pill tagged as see-more which just expands list of skills, it should be deselected for parsing.
- It should be possible to pass some parameters to Mechanize. I added the most useful one - `open_timeout` which is passed through Mechanize and Net::HTTP::Persistent to [Net::HTTP](http://ruby-doc.org/stdlib-2.3.1/libdoc/net/http/rdoc/Net/HTTP.html#attribute-i-open_timeout), it's especially useful with proxies.